### PR TITLE
Don't accept nil as a successful formatter output

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -115,6 +115,9 @@ function M.start_task(configs, start_line, end_line, opts)
 
       -- Success
       if ignore_exitcode or data == 0 then
+        if current_output == nil then
+          current_output = { "" }
+        end
         log.info(string.format("Finished running %s", name))
         output = transform and transform(current_output) or current_output
       end


### PR DESCRIPTION
If a formatter doesn't return anything, this results in a `current_output` value being `nil`. When passed to vim's internal functions like `vim.fn.chansend`, this gets transformed to the text `"v:null"`. Any further processors down the pipeline can't tell the difference between a transformed `nil` value and valid output that contains the text `"v:null"`, so that content is placed into the file as if it were the actual formatter output.

This PR replaces the `nil` with empty output (`{ "" }`) instead.

The expected case where a formatter returns nothing is when the input file is also empty, so this works as expected for that case.

Fixes #241